### PR TITLE
Remove import + instance creation lines

### DIFF
--- a/jenkins-config/jobs/job-prod-deploy.groovy
+++ b/jenkins-config/jobs/job-prod-deploy.groovy
@@ -1,5 +1,3 @@
-import javaposse.jobdsl.dsl.DslFactory
-DslFactory.newInstance().
 pipelineJob('prod-deploy') {
     parameters {
         stringParam( "PIPELINE_ID", "@PROD_PIPELINE_ID@" )

--- a/jenkins-config/jobs/job-stg-deploy.groovy
+++ b/jenkins-config/jobs/job-stg-deploy.groovy
@@ -1,5 +1,3 @@
-import javaposse.jobdsl.dsl.DslFactory
-DslFactory.newInstance().
 pipelineJob('stg-deploy') {
     parameters {
         stringParam( "PIPELINE_ID", "@STG_PIPELINE_ID@" )

--- a/jenkins-config/jobs/job-sync-repos.groovy
+++ b/jenkins-config/jobs/job-sync-repos.groovy
@@ -1,5 +1,3 @@
-import javaposse.jobdsl.dsl.DslFactory
-DslFactory.newInstance().
 pipelineJob('sync-repos') {
     definition {
         cps {


### PR DESCRIPTION
Removed lines responsible for importing `DslFactory` and creating its new instance from all pipeline job configuration files.
These two lines shouldn't be there in the first place, originally I added them in order to get syntax highlighting and were removing them in my gradle build script, so they never landed in the final Docker container.

According to the plugin [documentation](https://jenkinsci.github.io/job-dsl-plugin/#path/pipelineJob), the configuration should begin straight away with `pipelineJob`.

This fixes #1 
